### PR TITLE
pay attention to as_mut_ref (star exercise)

### DIFF
--- a/exercises/clippy/clippy1.rs
+++ b/exercises/clippy/clippy1.rs
@@ -9,12 +9,14 @@
 // Execute `rustlings hint clippy1` or use the `hint` watch subcommand for a
 // hint.
 
-// I AM NOT DONE
+/*
+介绍 clippy 这个 rust 代码分析工具，认为原来的代码没有语法上的错误，clippy 提供了修改意见。
+*/
 
 use std::f32;
 
 fn main() {
-    let pi = 3.14f32;
+    let pi = f32::consts::PI;
     let radius = 5.00f32;
 
     let area = pi * f32::powi(radius, 2);

--- a/exercises/clippy/clippy2.rs
+++ b/exercises/clippy/clippy2.rs
@@ -3,12 +3,13 @@
 // Execute `rustlings hint clippy2` or use the `hint` watch subcommand for a
 // hint.
 
-// I AM NOT DONE
-
 fn main() {
     let mut res = 42;
     let option = Some(12);
-    for x in option {
+    /*
+    clippy 提供更好的写法建议，对于设置成 Some(12) 类型的数据，最好对 Some 或者 None 做一个判断
+     */
+    if let Some(x) = option {
         res += x;
     }
     println!("{}", res);

--- a/exercises/clippy/clippy3.rs
+++ b/exercises/clippy/clippy3.rs
@@ -4,28 +4,37 @@
 //
 // Execute `rustlings hint clippy3` or use the `hint` watch subcommand for a hint.
 
-// I AM NOT DONE
-
 #[allow(unused_variables, unused_assignments)]
 fn main() {
     let my_option: Option<()> = None;
-    if my_option.is_none() {
-        my_option.unwrap();
+    if let Some(item) = my_option{
+        // 直接去掉 my_option.unwrap(), 因为 if let Some(item) = my_option 已经安全解包
+        // 这里的 Option 包裹的是一个单元类型 ()
     }
 
     let my_arr = &[
-        -1, -2, -3
+        -1, -2, -3,
         -4, -5, -6
     ];
     println!("My array! Here it is: {:?}", my_arr);
 
-    let my_empty_vec = vec![1, 2, 3, 4, 5].resize(0, 5);
-    println!("This Vec is empty, see? {:?}", my_empty_vec);
+    /*
+    问题在于 my_arr.resize(0, 5)
+    第一个参数是修改数组的长度为 5, 直接返回一个单元类型() ,表示无信息量，所以这里的绑定没有意义，直接删掉 let binding
+     */
+    println!("This Vec is empty, see? {:?}", ());
 
     let mut value_a = 45;
     let mut value_b = 66;
     // Let's swap these two!
-    value_a = value_b;
-    value_b = value_a;
+    /*
+    这里重新回顾一下所有权的问题
+    std::mem::swap(&mut value_a, &mut value_b);
+    接收的是两个变量的可变引用，执行之后 value_a 和 value_b 的值会互换，
+    但是它们的所有权仍然分别属于 value_a 和 value_b
+    不会改变变量的所有权，只是改变它们所指向的值。
+    在不转移所有权的情况下交换两个变量的值
+     */
+    std::mem::swap(&mut value_a, &mut value_b);
     println!("value a: {}; value b: {}", value_a, value_b);
 }

--- a/exercises/conversions/as_ref_mut.rs
+++ b/exercises/conversions/as_ref_mut.rs
@@ -8,9 +8,31 @@
 // hint.
 
 // I AM NOT DONE
+/*
+回顾之前 impl [trait X] for [type Y] 的语法
+指的是为某一种类型 Y 实现特征 X,
+在我过去的经验里，type Y 使用泛型参数来表示比较常见，用例是:
+struct MyGenericStruct<T>{
+    value: T
+}
+impl<T: Clone> MyTrait for MyGenericStruct<T> {}
+// 泛型结构体
+而之前的 [trait X] 部分，也需要表明传入的参数是哪一种类型,
+trait MyTrait<T> {
+    fn my_method(&self, item: T);
+}
+指定对应 trait 中的方法接收哪种类型的参数
++ AsRef<str>: 这里的 <str> 是 AsRef trait 的泛型参数，指明了想要实现的 trait 是针对 str 类型的引用
+实现了 AsRef<str> 的类型可以通过调用 .as_ref() 获得一个 &str 类型的引用
++ AsRef 本身是一个泛型 trait(泛型特征)，需要指定它的泛型参数类型。
+如果只写了 impl AsRef for T{}, 编译器不知道你想要把 T 转换成什么类型的引用，因为没有指定泛型参数。
+AsRef 需要知道你要"借用"成哪种类型，必须提供具体的类型参数。
+*/
 
 // Obtain the number of bytes (not characters) in the given argument.
 // TODO: Add the AsRef trait appropriately as a trait bound.
+
+
 fn byte_counter<T>(arg: T) -> usize {
     arg.as_ref().as_bytes().len()
 }

--- a/exercises/conversions/from_into.rs
+++ b/exercises/conversions/from_into.rs
@@ -40,10 +40,32 @@ impl Default for Person {
 // If while parsing the age, something goes wrong, then return the default of
 // Person Otherwise, then return an instantiated Person object with the results
 
-// I AM NOT DONE
 
 impl From<&str> for Person {
     fn from(s: &str) -> Person {
+        // 1. 第一步，需要判断对应的 string 是否有且只有一个逗号
+        // 如果有且只有一个逗号，执行后面的判断，否则直接返回 default
+        let comma_count = s.matches(',').count();
+        if comma_count != 1{
+            return Person::default();
+        }
+
+        // 2. 第二步，确认有且只有一个逗号后，转换前后两个部分
+        let parts: Vec<&str> = s.split(',').collect();
+        let (name_part, age_part) = (parts[0], parts[1]);
+
+        // 3. 判断 name 是否为空
+        if name_part.is_empty(){
+            return Person::default();
+        }
+
+        // 4. 转换 age 部分为 usize
+        match age_part.parse::<usize>(){
+            Ok(age) => Person{name: name_part.to_string(),
+                            age: age,
+            },
+            Err(_) => Person::default(),
+        }
     }
 }
 

--- a/exercises/conversions/from_str.rs
+++ b/exercises/conversions/from_str.rs
@@ -31,7 +31,6 @@ enum ParsePersonError {
     ParseInt(ParseIntError),
 }
 
-// I AM NOT DONE
 
 // Steps:
 // 1. If the length of the provided string is 0, an error should be returned
@@ -51,7 +50,44 @@ enum ParsePersonError {
 
 impl FromStr for Person {
     type Err = ParsePersonError;
+    /*
+    回顾之前的一个知识点，type 的作用是创建类型别名
+    就是为了表达的简略和方便，使用 Err 来代替 ParsePersonError
+    下面的 Err 就当成是 ParsePersonError 来使用
+     */
     fn from_str(s: &str) -> Result<Person, Self::Err> {
+        // 0. 直接判断 Empty 类型
+        if s.is_empty() {
+            return Err(Self::Err::Empty);
+        }
+        // 1. 还是按照之前的逗号模式来
+        let comma_count = s.matches(',').count();
+        if comma_count != 1 {
+            return Err(Self::Err::BadLen);
+        }
+        // 2. 接下来逗号模式匹配结束，都是只有一个逗号的情况，字符串 name 和 age 部分的匹配
+        let parts: Vec<&str> = s.split(',').collect();
+        let (name_part, age_part) = (parts[0], parts[1]);
+        
+        match name_part {
+            "" => {
+                // name_part 是空字符串，测试后面第二部分的情况 
+                Err(Self::Err::NoName)
+            }
+            _ => {
+                match age_part.parse::<usize>() {
+                   Ok(age) => {
+                        Ok(Person{
+                            name: name_part.to_string(),
+                            age: age,
+                        })
+                   },
+                   Err(e) => {
+                        Err(Self::Err::ParseInt(e))
+                   }
+                }
+            }
+        }
     }
 }
 

--- a/exercises/conversions/try_from_into.rs
+++ b/exercises/conversions/try_from_into.rs
@@ -27,8 +27,6 @@ enum IntoColorError {
     IntConversion,
 }
 
-// I AM NOT DONE
-
 // Your task is to complete this implementation and return an Ok result of inner
 // type Color. You need to create an implementation for a tuple of three
 // integers, an array of three integers, and a slice of integers.
@@ -41,6 +39,15 @@ enum IntoColorError {
 impl TryFrom<(i16, i16, i16)> for Color {
     type Error = IntoColorError;
     fn try_from(tuple: (i16, i16, i16)) -> Result<Self, Self::Error> {
+        let (r, g, b) = tuple;
+        if r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255 {
+            return Err(IntoColorError::IntConversion);
+        }
+        return Ok(Color {
+            red: r as u8,
+            green: g as u8,
+            blue: b as u8,
+        });
     }
 }
 
@@ -48,6 +55,9 @@ impl TryFrom<(i16, i16, i16)> for Color {
 impl TryFrom<[i16; 3]> for Color {
     type Error = IntoColorError;
     fn try_from(arr: [i16; 3]) -> Result<Self, Self::Error> {
+
+        let (r, g, b) = (arr[0], arr[1], arr[2]);
+        Self::try_from((r,g,b))         // 这里必须要使用 Self 的原因是，rust编译器不知道究竟是属于哪一个 trait 或者类型的 try_from 方法
     }
 }
 
@@ -55,6 +65,11 @@ impl TryFrom<[i16; 3]> for Color {
 impl TryFrom<&[i16]> for Color {
     type Error = IntoColorError;
     fn try_from(slice: &[i16]) -> Result<Self, Self::Error> {
+        if slice.len() != 3 {
+            return Err(IntoColorError::BadLen);
+        }
+        let (r, g, b) = (slice[0], slice[1], slice[2]);
+        Self::try_from((r,g,b))
     }
 }
 

--- a/exercises/conversions/using_as.rs
+++ b/exercises/conversions/using_as.rs
@@ -10,11 +10,10 @@
 // Execute `rustlings hint using_as` or use the `hint` watch subcommand for a
 // hint.
 
-// I AM NOT DONE
 
 fn average(values: &[f64]) -> f64 {
     let total = values.iter().sum::<f64>();
-    total / values.len()
+    total / values.len() as f64
 }
 
 fn main() {


### PR DESCRIPTION
认为这个 as_mut_ref.rs 的练习比较有价值，回顾了泛型参数在特征trait 和类型 Type 中的使用
两者都可以指定对应的泛型参数，例子
trait Mytrait<T>{
     fn my_method(&self. item:T){}
}  指定传入的参数类型
impl<T:Clone> AsRef<str> for MyGenericType<T>{}
表示为自定义的 MyGenericType 结构体，其中的成员 T 必须实现 Clone 方法，实现一个 AsRef 的转换，转换成 str 类型的引用